### PR TITLE
Merge Samsung TV (Tizen) into pexel-wallpaper as third frontend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Pexels Dynamic Wallpaper — a static web app (hosted on GitHub Pages at `docs/`) that displays a rotating slideshow of Pexels collection photos. Designed to be used as a desktop wallpaper source via Plash (macOS) or Lively (Windows). A Node script fetches photo URLs from the Pexels API and writes them to a local text file used as the fallback image source.
+Pexels Dynamic Wallpaper — a static web app (hosted on GitHub Pages at `docs/`) that displays a rotating slideshow of Pexels collection photos. Powers three frontends from a single codebase: Plash (macOS), Lively (Windows), and a Samsung Smart TV app built with Tizen Studio (`docs/config.xml`). A Node script fetches photo URLs from the Pexels API and writes them to a local text/JSON file used as the fallback source.
 
 ## Commands
 
@@ -47,6 +47,12 @@ Static site served by GitHub Pages. All JS uses native ES modules (`.mjs`).
 
 ### Backend (`fetch_pexels_urls.mjs`)
 Standalone Node ESM script (zero deps) that fetches all photos from a hardcoded Pexels collection (`COLLECTION_ID = "vmnecek"`) with retry logic and rate limit (429) handling, writes URLs to `docs/pexels_photo_urls.txt` and metadata to `docs/pexels_photo_data.json`. Runs daily via GitHub Actions (`.github/workflows/update_photos.yml`).
+
+### Tizen / Samsung TV frontend
+- `docs/config.xml` is the Tizen widget manifest. CSP allows `connect-src 'self' https://geert.github.io` for the JSON fetch and `img-src https://images.pexels.com` for photos. No `script-src` other than `'self'` — Samsung Store rejects remote JS.
+- `docs/.tzpkgignore` lists files that don't need to be in the `.wgt`. If your Tizen Studio version ignores it, configure exclusions under Project Properties > Tizen Studio > Package.
+- Tizen detection: `isTizenTV()` checks `typeof tizen !== 'undefined' && typeof tizen.power !== 'undefined'`. When true: settings UI is hidden, URL params are ignored, `loadDefaults()` is called with `REMOTE_PHOTO_DATA_URL` instead of the relative path.
+- D-pad remote keys (arrow keys / OK / Play / Back) are wired unconditionally in `attachEventListeners` — they're no-ops outside Tizen unless the host (Plash interactive, browser) forwards keyboard events.
 
 ### Tests (`__tests__/script.test.js`)
 Jest with jsdom. Tests import directly from the ESM modules. `jest.setup.js` provides `fetch`, `TextEncoder`, and `matchMedia` mocks.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Pexels Dynamic Wallpaper
 
-Set your desktop to a dynamic slideshow of beautiful images from your favorite Pexels collections using the [Plash app (Mac OS)](https://apps.apple.com/us/app/plash/id1494023538) or [Lively App (Windows)](https://apps.microsoft.com/detail/9NTM2QC6QWS7)
+Set your desktop or TV to a dynamic slideshow of beautiful images from your favorite Pexels collections. The same web app powers three frontends:
 
-This web application provides the Pexels integration for Plash or Lively, allowing you to easily configure and display high-quality wallpapers.
+- **macOS** via [Plash](https://apps.apple.com/us/app/plash/id1494023538) — hosts the live URL as a desktop background
+- **Windows** via [Lively](https://apps.microsoft.com/detail/9NTM2QC6QWS7) — same idea on Windows
+- **Samsung Smart TV** via a Tizen `.wgt` built from this repo — bundles the app locally, fetches photo metadata from GitHub Pages at runtime
 
 [Live Demo](https://geert.github.io/pexel-wallpaper/)
 
@@ -23,6 +25,23 @@ To get started, follow these steps which are also displayed in the settings form
    *  Download and install from the [Microsoft Store](https://apps.microsoft.com/detail/9NTM2QC6QWS7)
 2. **Add Web App to Lively:**
    *  In Lively, choose the + button, add this URL: `https://geert.github.io/pexel-wallpaper/`
+
+### Samsung Smart TV (Tizen)
+
+The TV build runs entirely from the bundled `.wgt`; it does not contact the Pexels API and shows no settings UI. Only the photo metadata JSON and the photo images themselves are fetched at runtime (allowed by the Samsung Store CSP).
+
+1. **Open the project in Tizen Studio:** open `docs/` as a Tizen TV project (`config.xml` lives there).
+2. **Build the `.wgt`** via Tizen Studio's Build Package action.
+3. **Install on a Samsung TV** via Smart Development Bridge (sdb) or sideload via developer mode.
+
+Remote control:
+
+| Button | Action |
+|---|---|
+| OK / Enter / Play | Toggle photo info overlay (bottom-right) |
+| Right arrow | Next photo |
+| Left arrow | Previous photo |
+| Back | Exit app |
 
 ### Configure Pexels Wallpaper
 1.  **Enter Pexels API Key:**
@@ -48,10 +67,12 @@ Your Desktop will now cycle through images from your selected Pexels collection!
 
 ## Features
 
-*   Direct integration with Pexels collections via their API.
-*   User-friendly setup through an interactive form.
+*   Direct integration with Pexels collections via their API (Plash/Lively/browser).
+*   User-friendly setup through an interactive form (Plash/Lively/browser).
 *   Multi-language support (EN, NL, DE, FR).
 *   Fallback to local image URLs if no API key is provided (requires `pexels_photo_urls.txt` in the `docs/` folder with image URLs, one per line).
+*   Samsung TV build (Tizen `.wgt`) that fetches photo metadata at runtime from GitHub Pages; no API key needed.
+*   Keyboard / remote navigation (arrow keys + OK) works in any interactive frontend.
 
 ## License
 

--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -94,6 +94,59 @@ describe('utility functions', () => {
   });
 });
 
+describe('environment detection', () => {
+  let detectEnvironment, isTizenTV;
+
+  beforeAll(async () => {
+    ({ detectEnvironment, isTizenTV } = await import('../docs/js/main.mjs'));
+  });
+
+  beforeEach(() => {
+    const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+      url: 'https://example.com/',
+      pretendToBeVisual: true,
+    });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.navigator = dom.window.navigator;
+    delete global.tizen;
+  });
+
+  afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.navigator;
+    delete global.tizen;
+  });
+
+  test('isTizenTV returns false when tizen global is absent', () => {
+    expect(isTizenTV()).toBe(false);
+  });
+
+  test('isTizenTV returns true when tizen.power is present', () => {
+    global.tizen = { power: {} };
+    expect(isTizenTV()).toBe(true);
+  });
+
+  test('isTizenTV returns false when tizen exists but lacks power namespace', () => {
+    global.tizen = {};
+    expect(isTizenTV()).toBe(false);
+  });
+
+  test('detectEnvironment returns usageTizenTV on a Tizen TV', () => {
+    global.tizen = { power: {} };
+    expect(detectEnvironment()).toBe('usageTizenTV');
+  });
+
+  test('detectEnvironment returns a non-Tizen env when tizen is absent', () => {
+    Object.defineProperty(global.navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+      configurable: true,
+    });
+    expect(detectEnvironment()).not.toBe('usageTizenTV');
+  });
+});
+
 describe('extractPexelsId', () => {
   let extractPexelsId;
 

--- a/docs/.tzpkgignore
+++ b/docs/.tzpkgignore
@@ -1,0 +1,11 @@
+# Files excluded from the Tizen .wgt package.
+# These are needed by the web frontend (GitHub Pages) but redundant in the
+# Tizen build: the TV always fetches pexels_photo_data.json from
+# https://geert.github.io/pexel-wallpaper/ at runtime (see config.xml CSP).
+#
+# If your Tizen Studio version does not honor .tzpkgignore, configure these
+# exclusions manually under Project Properties > Tizen Studio > Package.
+pexels_photo_data.json
+pexels_photo_urls.txt
+manifest.json
+superpowers/

--- a/docs/config.xml
+++ b/docs/config.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<widget xmlns="http://www.w3.org/ns/widgets"
+        xmlns:tizen="http://tizen.org/ns/widgets"
+        id="http://github.com/Geert/pexel-wallpaper"
+        version="1.11.0"
+        viewmodes="maximized">
+
+    <tizen:application id="PxlWallppr.TizenWallpaper"
+                       package="PxlWallppr"
+                       required_version="2.3"/>
+
+    <content src="index.html"/>
+
+    <icon src="images/icon-128.png"/>
+    <name>Pexel Wallpaper</name>
+    <description>Fullscreen wallpaper slideshow from Pexels collections</description>
+
+    <tizen:profile name="tv-samsung"/>
+    <tizen:setting screen-orientation="landscape"
+                   context-menu="disable"
+                   hwkey-event="enable"
+                   background-support="disable"/>
+
+    <!-- External origins the app may contact -->
+    <access origin="https://images.pexels.com" subdomains="true"/>
+    <access origin="https://geert.github.io" subdomains="true"/>
+
+    <!-- Privileges -->
+    <tizen:privilege name="http://tizen.org/privilege/power"/>
+    <tizen:privilege name="http://tizen.org/privilege/tv.inputdevice"/>
+
+    <!-- Content Security Policy -->
+    <tizen:content-security-policy>
+        default-src 'self';
+        script-src 'self';
+        style-src 'self' 'unsafe-inline';
+        img-src 'self' https://images.pexels.com https://*.pexels.com data:;
+        connect-src 'self' https://geert.github.io;
+    </tizen:content-security-policy>
+</widget>

--- a/docs/js/config.mjs
+++ b/docs/js/config.mjs
@@ -1,6 +1,8 @@
 export const APP_VERSION = '1.1.0';
 export const LOCAL_IMAGE_URLS_FILE = 'pexels_photo_urls.txt';
 export const LOCAL_IMAGE_DATA_FILE = 'pexels_photo_data.json';
+export const REMOTE_PHOTO_DATA_URL =
+  'https://geert.github.io/pexel-wallpaper/pexels_photo_data.json';
 export const CHANGE_INTERVAL_MS = 300000; // 5 minutes
 export const PHOTO_SIZE_TO_DISPLAY = 'original';
 export const PEXELS_BASE_URL = 'https://api.pexels.com/v1/';

--- a/docs/js/i18n.mjs
+++ b/docs/js/i18n.mjs
@@ -24,6 +24,7 @@ const FALLBACK_TRANSLATIONS = {
     usageBrowserMac: 'Browser on macOS',
     usageBrowserWindows: 'Browser on Windows',
     usageBrowserOther: 'Browser',
+    usageTizenTV: 'Samsung TV',
     instructions: {
       mac: {
         step1Prefix: 'Install Plash:',

--- a/docs/js/main.mjs
+++ b/docs/js/main.mjs
@@ -2,6 +2,7 @@ import {
   APP_VERSION,
   LOCAL_IMAGE_URLS_FILE,
   LOCAL_IMAGE_DATA_FILE,
+  REMOTE_PHOTO_DATA_URL,
   CHANGE_INTERVAL_MS,
   STORAGE_KEYS,
 } from './config.mjs';
@@ -39,7 +40,8 @@ const $ = (id) => document.getElementById(id);
 
 // --- Environment Detection ---
 
-function detectEnvironment() {
+export function detectEnvironment() {
+  if (isTizenTV()) return 'usageTizenTV';
   const ua = (navigator.userAgent || '').toLowerCase();
   const platform = (navigator.platform || '').toLowerCase();
   if (typeof window.livelyPropertyListener === 'function' || window.chrome?.webview) {
@@ -239,7 +241,7 @@ async function loadDefaults() {
       currentTranslations: t,
       showStatus,
       hideStatus,
-      localImageDataFile: LOCAL_IMAGE_DATA_FILE,
+      localImageDataFile: isTizenTV() ? REMOTE_PHOTO_DATA_URL : LOCAL_IMAGE_DATA_FILE,
       localImageUrlsFile: LOCAL_IMAGE_URLS_FILE,
     });
     const normalized = normalizeEntries(images);
@@ -272,7 +274,7 @@ export function extractCollectionIdFromUrl(url) {
 
 // --- Settings Button Auto-Hide ---
 
-function isTizenTV() {
+export function isTizenTV() {
   try {
     return typeof tizen !== 'undefined' && typeof tizen.power !== 'undefined';
   } catch (_e) {
@@ -388,6 +390,12 @@ function translatePage() {
 // --- Configuration ---
 
 function handleConfiguration() {
+  // Tizen TV: no settings UI, no URL params — always fetch the remote default JSON.
+  if (isTizenTV()) {
+    loadDefaults();
+    return;
+  }
+
   const params = new URLSearchParams(window.location.search);
   const apiKey = params.get('apiKey');
   const collectionUrl = params.get('collectionUrl');

--- a/docs/js/translations.json
+++ b/docs/js/translations.json
@@ -45,6 +45,7 @@
         "usageBrowserMac": "Browser on macOS",
         "usageBrowserWindows": "Browser on Windows",
         "usageBrowserOther": "Browser",
+        "usageTizenTV": "Samsung TV",
         "instructions": {
             "mac": {
                 "step1Prefix": "Install Plash:",
@@ -136,6 +137,7 @@
         "usageBrowserMac": "Browser op macOS",
         "usageBrowserWindows": "Browser op Windows",
         "usageBrowserOther": "Browser",
+        "usageTizenTV": "Samsung TV",
         "instructions": {
             "mac": {
                 "step1Prefix": "Installeer Plash:",
@@ -227,6 +229,7 @@
         "usageBrowserMac": "Browser auf macOS",
         "usageBrowserWindows": "Browser auf Windows",
         "usageBrowserOther": "Browser",
+        "usageTizenTV": "Samsung TV",
         "instructions": {
             "mac": {
                 "step1Prefix": "Installieren Sie Plash:",
@@ -318,6 +321,7 @@
         "usageBrowserMac": "Navigateur sur macOS",
         "usageBrowserWindows": "Navigateur sur Windows",
         "usageBrowserOther": "Navigateur",
+        "usageTizenTV": "Samsung TV",
         "instructions": {
             "mac": {
                 "step1Prefix": "Installez Plash :",

--- a/docs/superpowers/specs/2026-05-17-tizen-merge-design.md
+++ b/docs/superpowers/specs/2026-05-17-tizen-merge-design.md
@@ -1,0 +1,178 @@
+# Tizen-merge: Samsung TV als derde frontend
+
+**Datum:** 2026-05-17
+**Status:** approved (sectie 1–3)
+
+## Doel
+
+[`Geert/tizenwallpaper`](https://github.com/Geert/tizenwallpaper) opheffen en zijn functionaliteit overbrengen naar `Geert/pexel-wallpaper` als een derde frontend naast Plash (macOS) en Lively (Windows). De Tizen-app haalt zijn photo-metadata op runtime op van GitHub Pages in plaats van een gebundelde JSON. Bron- en code-duplicatie tussen de twee repos verdwijnt.
+
+## Achtergrond
+
+De twee repos zijn voor 95% identiek: CSS, `storage.mjs`, `status.mjs`, `i18n.mjs` en `translations.json` zijn 1:1, en `main.mjs` verschilt op drie plekken die allemaal met runtime-detectie opgelost kunnen worden. `pexel-wallpaper` heeft al een `isTizenTV()`-functie en gebruikt die voor het verbergen van de settings-knop. Photo-info bij OK/Enter en arrow-key navigatie zijn al universeel geïmplementeerd in `pexel-wallpaper/docs/js/main.mjs`.
+
+De Samsung Store CSP staat geen remote JavaScript toe; wel JSON en images van toegestane origins. De huidige `config.xml` in tizenwallpaper bevat `connect-src https://geert.github.io` — runtime JSON-fetch is dus al toegestaan.
+
+Offline-caching heeft nooit als bewuste feature bestaan in de repo (geverifieerd in git history). Het "gedeeltelijke" offline-gedrag komt uit de standaard browser HTTP-cache op de Pexels CDN images. Dit blijft zo — geen service worker, geen image-prefetch in scope.
+
+## Architectuur
+
+### Drie frontends, één codebase
+
+| Frontend | Detectie | Settings-UI | Config-bron | Arrow/OK keys | JSON-bron |
+|---|---|---|---|---|---|
+| Plash (macOS) | `is-plash-app` class / UA `plash` | Op pointer/key-activiteit | URL params → localStorage → defaults | Werken bij interactiviteit | Lokaal `./pexels_photo_data.json` |
+| Lively (Windows) | UA `livelywallpaper` / `window.livelyPropertyListener` | Op pointer/key-activiteit | Idem | Werken bij interactiviteit | Lokaal `./pexels_photo_data.json` |
+| Samsung TV | `typeof tizen !== 'undefined'` | Altijd verborgen | Altijd `loadDefaults()` (geen API) | Altijd actief (D-pad) | Remote `https://geert.github.io/pexel-wallpaper/pexels_photo_data.json` |
+
+### Repo-structuur na merge
+
+```
+docs/
+  index.html
+  config.xml          ← NIEUW: Tizen widget manifest (Tizen Studio opent docs/ als project)
+  .tizenignore        ← NIEUW: sluit pexels_photo_data.json + pexels_photo_urls.txt + manifest.json uit van .wgt
+  manifest.json       ongewijzigd (PWA manifest voor web, niet Tizen)
+  images/
+    favicon.ico, icon-16/32/180.png        index.html refs
+    icon-192/256/512.png                   manifest.json refs (+ Samsung Store gebruikt 512)
+    icon-128.png                           config.xml refs (als app-icon)
+    icon-48.png, icon-64.png               nog steeds unreferenced (zie open vragen)
+  css/style.css       ongewijzigd
+  js/
+    main.mjs          gewijzigd
+    slideshow.mjs     gewijzigd
+    config.mjs        gewijzigd (constant toegevoegd)
+    i18n.mjs          gewijzigd (nieuwe label)
+    translations.json gewijzigd (nieuwe label, 4 talen)
+    storage.mjs       ongewijzigd
+    status.mjs        ongewijzigd
+```
+
+### config.xml (basis uit tizenwallpaper)
+
+Wijzigingen t.o.v. de huidige tizenwallpaper-versie:
+- `<icon src="images/icon-128.png"/>` (was `<icon src="icon.png"/>` op tizen root — vervalt)
+- `connect-src` in CSP: alleen `'self'` en `https://geert.github.io`. `api.pexels.com` verwijderd; de Tizen-build belt de Pexels API nooit direct.
+
+### Build & distributie
+
+Geen build-script en geen CI voor `.wgt`. De ontwikkelaar opent `docs/` als project in Tizen Studio en bouwt daar handmatig. De `.tizenignore` zorgt dat de gegenereerde `.wgt` geen onnodige metadata-bestanden bevat (de JSON wordt remote opgehaald).
+
+## Componenten
+
+### 1. `detectEnvironment()` in [main.mjs](../../js/main.mjs)
+
+Voeg `'usageTizenTV'` toe als return-waarde, vóór de bestaande Plash/Lively/browser checks:
+
+```js
+function detectEnvironment() {
+  if (typeof tizen !== 'undefined') return 'usageTizenTV';
+  // ...bestaande logica
+}
+```
+
+### 2. `handleConfiguration()` in [main.mjs](../../js/main.mjs)
+
+Gate op `isTizenTV()`:
+
+```js
+function handleConfiguration() {
+  if (isTizenTV()) {
+    loadDefaults();
+    return;
+  }
+  // ...bestaande URL-param + localStorage flow
+}
+```
+
+### 3. `loadDefaultPhotoData()` in [slideshow.mjs](../../js/slideshow.mjs)
+
+Nieuwe (of gewijzigde) helper die de bron kiest:
+
+```js
+const source = isTizenTV()
+  ? REMOTE_PHOTO_DATA_URL
+  : LOCAL_IMAGE_DATA_FILE;
+const response = await fetch(source, { signal });
+// op fail: status.mjs toont error overlay, geen retry, geen localStorage fallback
+```
+
+`REMOTE_PHOTO_DATA_URL` als nieuwe constant in [config.mjs](../../js/config.mjs):
+
+```js
+export const REMOTE_PHOTO_DATA_URL =
+  'https://geert.github.io/pexel-wallpaper/pexels_photo_data.json';
+```
+
+### 4. i18n label
+
+Voeg `usageTizenTV` toe aan [i18n.mjs](../../js/i18n.mjs) fallback object en aan [translations.json](../../js/translations.json) voor EN, NL, DE, FR. Voorbeeld-waarde EN: `"Samsung TV"`.
+
+## Datastromen
+
+### Tizen-app startup
+
+```
+opstart
+  → handleConfiguration() → isTizenTV() == true → loadDefaults()
+  → loadDefaultPhotoData() → fetch(REMOTE_PHOTO_DATA_URL)
+      ├─ ok: parse JSON, init slideshow
+      └─ fail (network/timeout/4xx/5xx): showStatus(t.statusErrorNetwork)
+                                        slideshow blijft leeg
+```
+
+### Web-frontend startup (Plash/Lively/browser)
+
+Onveranderd:
+```
+opstart
+  → handleConfiguration() → check URL params / localStorage
+      ├─ apiKey + collectionId aanwezig: loadFromAPI() (24h URL-cache via storage.mjs)
+      └─ niet aanwezig: loadDefaults() → fetch(LOCAL_IMAGE_DATA_FILE)
+```
+
+## Error handling
+
+- **Tizen fetch faalt:** standaard `t.statusErrorNetwork` overlay via [status.mjs](../../js/status.mjs). Geen retry-logica, geen fallback. Bij volgende app-start wordt de fetch opnieuw geprobeerd.
+- **Tizen fetch 4xx/5xx:** zelfde overlay. Operationeel ongebruikelijk; alleen relevant als GitHub Pages down is of we de JSON-naam wijzigen.
+- **Web-frontends:** ongewijzigd. Bestaande error paths blijven.
+
+## Testen
+
+- **Bestaande Jest-tests:** moeten blijven slagen. `__tests__/script.test.js` mockt `fetch` al; eventueel een nieuwe test toevoegen voor de Tizen-source-keuze in `loadDefaultPhotoData`.
+- **Handmatige Tizen-test:** open `docs/` in Tizen Studio, bouw `.wgt`, installeer op een Samsung TV of Tizen TV emulator, verifieer dat:
+  - Settings-knop niet zichtbaar is
+  - Slideshow start vanuit remote JSON
+  - OK toont info bottom-right; arrows next/prev werken
+  - Bij offline-boot verschijnt de error-overlay
+- **Handmatige Plash-test:** start Plash met de github.io URL; in browsing-mode verschijnt settings-knop bij activiteit, OK toont info, arrows navigeren.
+- **Geen test voor Lively** (geen toegang) — code-paden zijn identiek aan Plash, dus dekking via Plash-test.
+
+## Migratie van oude tizenwallpaper repo
+
+1. In `Geert/tizenwallpaper`: commit een nieuwe `README.md` die naar `pexel-wallpaper` verwijst en uitleg geeft over de samengevoegde structuur.
+2. GitHub Settings → "Archive this repository".
+3. Geen file deletion, geen redirects in DNS — bestaande Samsung Store-listings en clones blijven werken voor wie de oude versie heeft, en de history blijft zichtbaar.
+
+## Wat niet in scope is
+
+- **Service worker / image-caching:** geen "echte" offline. Browser-HTTP-cache blijft het lichte werk doen.
+- **CI-build voor `.wgt`:** lokaal via Tizen Studio.
+- **Sync-mechanisme tizenwallpaper → pexel-wallpaper:** niet nodig na merge.
+- **Photo-info-uitbreiding:** huidige weergave (alt + photographer) blijft.
+- **Ongebruikte icons** (`icon-48.png`, `icon-64.png`): blijven staan; aparte cleanup-taak.
+
+## Open vragen
+
+Geen — alle drie de secties zijn besproken en goedgekeurd.
+
+## Acceptatiecriteria
+
+- [ ] `docs/config.xml` aanwezig, Tizen Studio opent `docs/` zonder errors
+- [ ] `.wgt` build bevat geen `pexels_photo_data.json` of `pexels_photo_urls.txt`
+- [ ] Op een Tizen TV: settings-knop nooit zichtbaar, slideshow start, OK toont info, arrows navigeren
+- [ ] In Plash interactieve modus: settings-knop verschijnt bij muis, OK toont info, arrows navigeren
+- [ ] In Plash niet-interactieve modus: geen UI-chrome zichtbaar
+- [ ] Jest-suite slaagt
+- [ ] `Geert/tizenwallpaper` repo is gearchiveerd met deprecation-README


### PR DESCRIPTION
## Summary

- Adds Samsung Smart TV (Tizen) as a third frontend alongside Plash (macOS) and Lively (Windows), driven by runtime detection (`isTizenTV()`).
- The Tizen `.wgt` bundles all JS/CSS/HTML (Samsung Store CSP forbids remote scripts) but fetches the photo metadata JSON from `https://geert.github.io/pexel-wallpaper/pexels_photo_data.json` at runtime — collection updates no longer require an app rebuild.
- Retires `Geert/tizenwallpaper` as the source of truth (95% duplicated code). After this merges, that repo should be archived with a deprecation README.

Design spec: [`docs/superpowers/specs/2026-05-17-tizen-merge-design.md`](https://github.com/Geert/pexel-wallpaper/blob/tizen-merge/docs/superpowers/specs/2026-05-17-tizen-merge-design.md)

## What changed

| File | Change |
|---|---|
| `docs/js/config.mjs` | New `REMOTE_PHOTO_DATA_URL` constant |
| `docs/js/main.mjs` | `detectEnvironment` returns `'usageTizenTV'` first; `handleConfiguration` short-circuits to `loadDefaults` on Tizen; `loadDefaults` passes remote URL when on Tizen. Exports `detectEnvironment` + `isTizenTV` for testing. |
| `docs/js/i18n.mjs` + `translations.json` | New `usageTizenTV` label in 4 languages |
| `docs/config.xml` | Tizen widget manifest (adapted from tizenwallpaper, CSP tightened to drop `api.pexels.com` since the TV build never hits the Pexels API directly) |
| `docs/.tzpkgignore` | Excludes fallback JSON/txt from `.wgt` build |
| `README.md` + `CLAUDE.md` | Document three-frontend architecture and remote-control behavior |
| `__tests__/script.test.js` | 5 new tests for `isTizenTV` + `detectEnvironment` |

## Test plan

- [x] `npm test` — all 33 tests pass (28 existing + 5 new)
- [x] `npm run lint` — ESLint + Prettier clean
- [ ] **On the Tizen Studio machine:** open `docs/` as a Tizen TV project, build the `.wgt`, install on a Samsung TV
- [ ] Verify on the TV:
  - [ ] Settings button never appears
  - [ ] Slideshow starts (fetches JSON from GH Pages)
  - [ ] OK/Enter toggles photo info bottom-right
  - [ ] Left/Right arrows navigate prev/next
  - [ ] Back exits the app
  - [ ] Disconnect Wi-Fi at boot → error overlay appears (no offline fallback by design)
- [ ] Verify in Plash interactive mode on macOS: settings button appears on mouse activity; OK/arrows still work
- [ ] After merging this PR: archive `Geert/tizenwallpaper` with a deprecation README pointing here

## Notes

- `.tzpkgignore` is the documented Samsung name. If your Tizen Studio version doesn't honor it, configure exclusions under Project Properties > Tizen Studio > Package. The fallback JSON files are ~340KB total — harmless if they ship.
- The Tizen icon reuses the existing `docs/images/icon-128.png`; no separate `icon.png` is added.
- The CSS, storage.mjs, status.mjs, and i18n.mjs were already 1:1 identical between the two repos — no changes needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)