### PR TITLE
fix: remove api.pexels.com preconnect breaking Tizen CSP

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,6 @@
     <link rel="apple-touch-icon" sizes="180x180" href="images/icon-180.png" />
     <link rel="manifest" href="manifest.json" />
     <meta name="theme-color" content="#0066ff" />
-    <link rel="preconnect" href="https://api.pexels.com" crossorigin />
     <link rel="preconnect" href="https://images.pexels.com" />
   </head>
   <body>


### PR DESCRIPTION
## Summary
The Samsung TV build shows a black screen with a red CSP-violation banner in the top-left because `index.html` preconnects to `https://api.pexels.com`, which the Tizen `config.xml` does not (and should not) whitelist in `connect-src`. The TV frontend never calls the Pexels API directly — it only fetches `pexels_photo_data.json` from `https://geert.github.io/...`.

Removing the preconnect costs at most a few hundred ms of warm-up time on the first Pexels API request in the desktop/browser builds and resolves the Tizen failure.

## Test plan
- [x] `npm test` — 33/33 passing
- [ ] Reinstall `.wgt` on TV when free and confirm slideshow loads (red banner gone)
- [x] No change to `config.xml` CSP; surface area on web build is unchanged apart from the missing perf hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)